### PR TITLE
Fix packaging path and extension suffix

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -17,4 +17,4 @@ if [ -z "$SO_FILE" ]; then
     exit 1
 fi
 
-mv "$SO_FILE" ../pysrc/tensorium/
+mv "$SO_FILE" ../Pysrc/tensorium/

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
-import os, subprocess, sys
+import os
+import subprocess
+import sys
 
 
 class CMakeExtension(Extension):
@@ -25,14 +27,12 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp)
         subprocess.check_call(["cmake", "--build", ".", "--target", "tensorium"] + build_args, cwd=self.build_temp)
 
-    def get_ext_filename(self, ext_name):
-        return f"{ext_name}.cpython-{sys.version_info.major}{sys.version_info.minor}-darwin.so"
 
 setup(
     name="tensorium",
     version="0.1.0",
-    package_dir={"": "pysrc"},
-    packages=find_packages(where="pysrc"),
+    package_dir={"": "Pysrc"},
+    packages=find_packages(where="Pysrc"),
     ext_modules=[CMakeExtension("tensorium")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,


### PR DESCRIPTION
## Summary
- correct editable install path
- use default extension naming

## Testing
- `pytest -q`
- `pip install -e .` *(fails: Findpybind11.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_68441f2a36b08332a1d251344a520509